### PR TITLE
Add MIDI controlled model switching

### DIFF
--- a/resources/modgui.ttl
+++ b/resources/modgui.ttl
@@ -17,5 +17,9 @@
             lv2:index 1;
             lv2:symbol "output_level";
             lv2:name "Output Lvl";
+        ], [
+            lv2:index 2;
+            lv2:symbol "model_select";
+            lv2:name "Model Select";
         ];
     ].

--- a/resources/neural_amp_modeler.ttl.in
+++ b/resources/neural_amp_modeler.ttl.in
@@ -92,13 +92,21 @@ A large collection of models is available at https://tonehunt.org
 		lv2:minimum -20.0;
 		lv2:maximum 20.0;
 		units:unit units:db;
-	], [
-		a lv2:ControlPort, lv2:InputPort;
-		lv2:index 5;
-		lv2:symbol "output_level";
-		lv2:name "Output Lvl";
-		lv2:default 0.0;
-		lv2:minimum -20.0;
-		lv2:maximum 20.0;
-		units:unit units:db;
-	].
+        ], [
+                a lv2:ControlPort, lv2:InputPort;
+                lv2:index 5;
+                lv2:symbol "output_level";
+                lv2:name "Output Lvl";
+                lv2:default 0.0;
+                lv2:minimum -20.0;
+                lv2:maximum 20.0;
+                units:unit units:db;
+        ], [
+                a lv2:ControlPort, lv2:InputPort;
+                lv2:index 6;
+                lv2:symbol "model_select";
+                lv2:name "Model Select";
+                lv2:default 0;
+                lv2:minimum 0;
+                lv2:maximum 127;
+        ].

--- a/src/nam_plugin.cpp
+++ b/src/nam_plugin.cpp
@@ -2,6 +2,8 @@
 #include <cmath>
 #include <utility>
 #include <cassert>
+#include <cstring>
+#include <filesystem>
 
 #include "nam_plugin.h"
 
@@ -177,15 +179,16 @@ namespace NAM {
 		LV2FreeModelMsg reply = { kWorkTypeFree, nam->currentModel };
 
 		// swap current model with new one
-		nam->currentModel = msg->model;
-		nam->currentModelPath = msg->path;
-		assert(nam->currentModelPath.capacity() >= MAX_FILE_NAME + 1);
+                nam->currentModel = msg->model;
+                nam->currentModelPath = msg->path;
+                assert(nam->currentModelPath.capacity() >= MAX_FILE_NAME + 1);
+                nam->scan_model_directory(nam->currentModelPath);
 
 		// send reply
 		nam->schedule->schedule_work(nam->schedule->handle, sizeof(reply), &reply);
 
 		// report change to host/ui
-		nam->write_current_path();
+                nam->write_current_path();
 
 		return LV2_WORKER_SUCCESS;
 	}
@@ -202,10 +205,10 @@ namespace NAM {
 		lv2_atom_forge_set_buffer(&atom_forge, (uint8_t*)ports.notify, ports.notify->atom.size);
 		lv2_atom_forge_sequence_head(&atom_forge, &sequence_frame, uris.units_frame);
 
-		LV2_ATOM_SEQUENCE_FOREACH(ports.control, event)
-		{
-			if (event->body.type == uris.atom_Object)
-			{
+                LV2_ATOM_SEQUENCE_FOREACH(ports.control, event)
+                {
+                        if (event->body.type == uris.atom_Object)
+                        {
 				const auto obj = reinterpret_cast<LV2_Atom_Object*>(&event->body);
 				if (obj->body.otype == uris.patch_Get)
 				{
@@ -229,9 +232,25 @@ namespace NAM {
 						LV2LoadModelMsg msg = { kWorkTypeLoad, {} };
 						memcpy(msg.path, file_path + 1, file_path->size);
 						schedule->schedule_work(schedule->handle, sizeof(msg), &msg);
-					}
-				}
-			}
+                                }
+                        }
+                }
+
+                // MIDI-selectable model index
+                if (ports.model_select && !modelList.empty())
+                {
+                        int idx = static_cast<int>(*ports.model_select + 0.5f);
+                        if (idx >= 0 && idx < (int)modelList.size() && idx != prevModelSelect)
+                        {
+                                prevModelSelect = idx;
+                                currentModelIndex = idx;
+
+                                LV2LoadModelMsg msg = { kWorkTypeLoad, {} };
+                                strncpy(msg.path, modelList[idx].c_str(), MAX_FILE_NAME);
+                                msg.path[MAX_FILE_NAME - 1] = '\0';
+                                schedule->schedule_work(schedule->handle, sizeof(msg), &msg);
+                        }
+                }
 		}
 
 		float level;
@@ -458,8 +477,8 @@ namespace NAM {
 		return result;
 	}
 
-	void Plugin::write_current_path()
-	{
+        void Plugin::write_current_path()
+        {
 		LV2_Atom_Forge_Frame frame;
 
 		lv2_atom_forge_frame_time(&atom_forge, 0);
@@ -468,8 +487,48 @@ namespace NAM {
 		lv2_atom_forge_key(&atom_forge, uris.patch_property);
 		lv2_atom_forge_urid(&atom_forge, uris.model_Path);
 		lv2_atom_forge_key(&atom_forge, uris.patch_value);
-		lv2_atom_forge_path(&atom_forge, currentModelPath.c_str(), (uint32_t)currentModelPath.length() + 1);
+                lv2_atom_forge_path(&atom_forge, currentModelPath.c_str(), (uint32_t)currentModelPath.length() + 1);
 
-		lv2_atom_forge_pop(&atom_forge, &frame);
-	}
+                lv2_atom_forge_pop(&atom_forge, &frame);
+        }
+
+        void Plugin::scan_model_directory(const std::string& path)
+        {
+                namespace fs = std::filesystem;
+                fs::path p(path);
+                modelList.clear();
+                if (p.empty())
+                        return;
+
+                fs::path dir = p.parent_path();
+                if (!fs::exists(dir))
+                        return;
+
+                for (const auto& entry : fs::directory_iterator(dir))
+                {
+                        if (!entry.is_regular_file())
+                                continue;
+
+                        auto ext = entry.path().extension().string();
+                        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                        if (ext == ".nam" || ext == ".nammodel" || ext == ".json" || ext == ".aidax" || ext == ".aidadspmodel")
+                        {
+                                modelList.push_back(entry.path().string());
+                        }
+                }
+
+                std::sort(modelList.begin(), modelList.end());
+
+                currentModelIndex = -1;
+                for (size_t i = 0; i < modelList.size(); ++i)
+                {
+                        if (modelList[i] == currentModelPath)
+                        {
+                                currentModelIndex = (int)i;
+                                break;
+                        }
+                }
+
+                prevModelSelect = currentModelIndex;
+        }
 }

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <random>
 #include <string_view>
+#include <vector>
+#include <filesystem>
 
 // LV2
 #include <lv2/core/lv2.h>
@@ -53,14 +55,15 @@ namespace NAM {
 
 	class Plugin {
 	public:
-		struct Ports {
-			const LV2_Atom_Sequence* control;
-			LV2_Atom_Sequence* notify;
-			const float* audio_in;
-			float* audio_out;
-			float* input_level;
-			float* output_level;
-		};
+        struct Ports {
+                const LV2_Atom_Sequence* control;
+                LV2_Atom_Sequence* notify;
+                const float* audio_in;
+                float* audio_out;
+                float* input_level;
+                float* output_level;
+                float* model_select;
+        };
 
 		Ports ports = {};
 
@@ -70,10 +73,13 @@ namespace NAM {
 		LV2_Log_Logger logger = {};
 		LV2_Worker_Schedule* schedule = nullptr;
 
-		NeuralAudio::NeuralModel* currentModel = nullptr;
-		std::string currentModelPath;
-		float prevDCInput = 0;
-		float prevDCOutput = 0;
+                NeuralAudio::NeuralModel* currentModel = nullptr;
+                std::string currentModelPath;
+                std::vector<std::string> modelList;
+                int currentModelIndex = -1;
+                int prevModelSelect = -1;
+                float prevDCInput = 0;
+                float prevDCOutput = 0;
 
 		Plugin();
 		~Plugin();
@@ -82,7 +88,8 @@ namespace NAM {
 		void set_max_buffer_size(int size) noexcept;
 		void process(uint32_t n_samples) noexcept;
 
-		void write_current_path();
+                void write_current_path();
+                void scan_model_directory(const std::string& path);
 
 		static uint32_t options_get(LV2_Handle instance, LV2_Options_Option* options);
 		static uint32_t options_set(LV2_Handle instance, const LV2_Options_Option* options);


### PR DESCRIPTION
## Summary
- allow MIDI-controlled selection of amp models
- scan model directory to build model list
- update ports with a new control for model selection
- expose new parameter in LV2 metadata and MOD GUI

## Testing
- `cmake --version`
- `cmake ..` *(fails: does not contain a CMakeLists.txt in deps/NeuralAudio)*

------
https://chatgpt.com/codex/tasks/task_e_685c5871360c8325aef5e64241f36622