### PR TITLE
Keep MIDI model_select in sync with GUI changes

### DIFF
--- a/src/nam_plugin.cpp
+++ b/src/nam_plugin.cpp
@@ -184,7 +184,11 @@ namespace NAM {
                 assert(nam->currentModelPath.capacity() >= MAX_FILE_NAME + 1);
                 nam->scan_model_directory(nam->currentModelPath);
 
-		// send reply
+               // keep MIDI model_select parameter in sync when the model is
+               // changed via the GUI
+               nam->sync_model_select_port();
+
+                // send reply
 		nam->schedule->schedule_work(nam->schedule->handle, sizeof(reply), &reply);
 
 		// report change to host/ui
@@ -257,6 +261,10 @@ namespace NAM {
                                strncpy(msg.path, modelList[idx].c_str(), MAX_FILE_NAME);
                                msg.path[MAX_FILE_NAME - 1] = '\0';
                                schedule->schedule_work(schedule->handle, sizeof(msg), &msg);
+
+                               currentModelPath = msg.path;
+                               write_current_path();
+                               sync_model_select_port();
                        }
                }
 		}
@@ -487,7 +495,7 @@ namespace NAM {
 
         void Plugin::write_current_path()
         {
-		LV2_Atom_Forge_Frame frame;
+                LV2_Atom_Forge_Frame frame;
 
 		lv2_atom_forge_frame_time(&atom_forge, 0);
 		lv2_atom_forge_object(&atom_forge, &frame, 0, uris.patch_Set);
@@ -498,6 +506,18 @@ namespace NAM {
                 lv2_atom_forge_path(&atom_forge, currentModelPath.c_str(), (uint32_t)currentModelPath.length() + 1);
 
                 lv2_atom_forge_pop(&atom_forge, &frame);
+        }
+
+        void Plugin::sync_model_select_port() noexcept
+        {
+                if (ports.model_select)
+                {
+                        int idx = currentModelIndex;
+                        if (idx < 0)
+                                idx = 0;
+
+                        *(ports.model_select) = static_cast<float>(idx);
+                }
         }
 
         void Plugin::scan_model_directory(const std::string& path)
@@ -537,6 +557,8 @@ namespace NAM {
                         }
                 }
 
-                prevModelSelect = currentModelIndex;
+               prevModelSelect = currentModelIndex;
+
+                sync_model_select_port();
         }
 }

--- a/src/nam_plugin.h
+++ b/src/nam_plugin.h
@@ -89,6 +89,7 @@ namespace NAM {
 		void process(uint32_t n_samples) noexcept;
 
                 void write_current_path();
+                void sync_model_select_port() noexcept;
                 void scan_model_directory(const std::string& path);
 
 		static uint32_t options_get(LV2_Handle instance, LV2_Options_Option* options);


### PR DESCRIPTION
## Summary
- add `sync_model_select_port` helper
- call helper on model change and directory scan
- update GUI when model changes via MIDI port

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE="Release"` *(fails: deps/NeuralAudio missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fcfe7212c83258189bc070be37738